### PR TITLE
Tweet may contain up to 280 characters

### DIFF
--- a/QSTwitterDefines.h
+++ b/QSTwitterDefines.h
@@ -21,4 +21,4 @@
 #define kTwitterDMURL [NSURL URLWithString:@"https://api.twitter.com/1/direct_messages/new.json"]
 
 // Twitter *may* change this one day, who knows
-#define kMaxTweetLength 140
+#define kMaxTweetLength 280


### PR DESCRIPTION

Updated the max length of a tweet from 140 to 280 characters. 

![Captura de pantalla 2021-06-09 a las 0 54 47](https://user-images.githubusercontent.com/6883041/121267981-524bb700-c8bd-11eb-9cdd-aa21506ab3a2.png)

Docs: https://developer.twitter.com/en/docs/counting-characters